### PR TITLE
Adding support to specify message queue host and port

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,6 +47,9 @@ Possible values are:
 
 When you are using rabbitmq we will connect to localhost with the official rabbit mq client library.
 
+If you run rabbitmq on a different host than ``localhost`` you can use ``-DmessageQueueHost=otherhost`` and
+``-DmessageQueuePort=1234`` to modify host and port.
+
 ### queueNames
 
 You can subscribe to different queues with different names. You should separate names by a comma.

--- a/src/main/java/com/happyr/mq2php/Application.java
+++ b/src/main/java/com/happyr/mq2php/Application.java
@@ -127,8 +127,28 @@ public class Application {
             param = "rabbitmq";
         }
 
+        String host = System.getProperty("messageQueueHost");
+        if (host == null) {
+            //default
+            host = "localhost";
+        }
+
+        String portString = System.getProperty("messageQueuePort");
+        Integer port;
+        try {
+            port = Integer.parseInt(portString);
+        }
+        catch (NumberFormatException e) {
+            port = null;
+        }
+
         if (param.equalsIgnoreCase("rabbitmq")) {
-            return new RabbitMqClient(queueName, new MessageConsumer(getExecutor()));
+            if (port == null) {
+                //default for rabbitmq
+                port = 5672;
+            }
+            logger.info("Using rabbitmq at {}:{}", host, port);
+            return new RabbitMqClient(host, port, queueName, new MessageConsumer(getExecutor()));
         }
 
         throw new IllegalArgumentException("Could not find QueueClient implementation named " + param);

--- a/src/main/java/com/happyr/mq2php/queue/RabbitMqClient.java
+++ b/src/main/java/com/happyr/mq2php/queue/RabbitMqClient.java
@@ -26,12 +26,13 @@ public class RabbitMqClient implements QueueClient {
     protected String errorQueueName;
     protected MessageConsumer messageConsumer;
 
-    public RabbitMqClient(String queueName, MessageConsumer mc) {
+    public RabbitMqClient(String host, Integer port, String queueName, MessageConsumer mc) {
         messageConsumer = mc;
         this.queueName = queueName;
         errorQueueName = queueName + "_errors";
         ConnectionFactory factory = new ConnectionFactory();
-        factory.setHost("localhost");
+        factory.setHost(host);
+        factory.setPort(port);
         try {
             connection = factory.newConnection();
             channel = connection.createChannel();


### PR DESCRIPTION
This PR adds support to use additional system properties to specify host and port for the message queue connection